### PR TITLE
Add request spec for update method to cancel subscription

### DIFF
--- a/app/controllers/api/v1/subscriptions_controller.rb
+++ b/app/controllers/api/v1/subscriptions_controller.rb
@@ -12,7 +12,12 @@ class Api::V1::SubscriptionsController < ApplicationController
   end
 
   def update
-    #find subscription where customer id && tea id, change status to "Cancelled"
+    subscription = Subscription.find(params[:id])
+    if subscription.update(subscription_params)
+      render json: SubscriptionSerializer.new(subscription)
+    else 
+      render status: 404
+    end 
   end
 
   private 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,7 +3,9 @@ Rails.application.routes.draw do
   namespace :api do 
     namespace :v1 do 
 
-      resources :subscriptions, only: %i[index update create]
+      patch '/subscriptions/cancel', to: 'subscriptions#update' 
+
+      resources :subscriptions, only: %i[index create] 
     end
   end
 end

--- a/spec/requests/api/v1/subscriptions/subscription_request_spec.rb
+++ b/spec/requests/api/v1/subscriptions/subscription_request_spec.rb
@@ -27,6 +27,7 @@ RSpec.describe "Subscription endpoints" do
     expect(first[:attributes]).to include(:frequency)
     expect(first[:attributes][:tea_id]).to eq(tea.id)
     expect(first[:attributes][:customer_id]).to eq(customer.id)
+    expect(first[:attributes][:customer_id]).to_not eq(customer2.id)
   end
 
   it 'can create new subscription' do 
@@ -45,7 +46,6 @@ RSpec.describe "Subscription endpoints" do
     post '/api/v1/subscriptions', params: subscription_params
 
     subscription = JSON.parse(response.body, symbolize_names: true)
-    # require 'pry'; binding.pry
 
     expect(response).to be_successful 
     expect(subscription).to be_a(Hash)
@@ -62,5 +62,36 @@ RSpec.describe "Subscription endpoints" do
     expect(attributes).to include(:frequency)
     expect(attributes).to include(:tea_id)
     expect(attributes).to include(:customer_id)
+  end
+
+  it 'can cancel subscription' do 
+    customer = create(:customer)
+    tea = create(:tea)
+    subscription = create(:subscription, customer_id: customer.id, tea_id: tea.id)
+
+    expect(subscription[:status]).to eq("Inactive")
+
+    patch '/api/v1/subscriptions/cancel', params: { id: subscription.id, status: "Canceled" } 
+
+    subs = JSON.parse(response.body, symbolize_names: true)
+
+    expect(response).to be_successful 
+    expect(subs).to be_a(Hash)
+    expect(subs[:data]).to include(:id)
+    expect(subs[:data]).to include(:type)
+    expect(subs[:data]).to include(:attributes)
+
+    attributes = subs[:data][:attributes]
+
+    expect(attributes).to include(:title)
+    expect(attributes[:title]).to be_a(String)
+    expect(attributes).to include(:price)
+    expect(attributes[:price]).to be_a(Float)
+    expect(attributes).to include(:status)
+    expect(attributes[:status]).to eq("Canceled")
+    expect(attributes).to include(:frequency)
+    expect(attributes).to include(:tea_id)
+    expect(attributes).to include(:customer_id)
+
   end
 end


### PR DESCRIPTION
## Description of Changes:
closes #11 
This PR adds a request spec and update method in the subscription controller to change a subscription status to "cancelled." 

## Put an 'X' next to all that apply
New Test: [X]
New Feature:[X]
Bug Fix: []

## Before You Submit Ensure
All Tests Pass: [X]
Full Coverage: [] 99.42% - Error handling and sad path tests needed. 
Runs Locally: [X]
