### PR TITLE
Add exception handler and sad path tests for subscription controller

### DIFF
--- a/app/controllers/api/v1/subscriptions_controller.rb
+++ b/app/controllers/api/v1/subscriptions_controller.rb
@@ -6,7 +6,11 @@ class Api::V1::SubscriptionsController < ApplicationController
   end
 
   def create 
-    render json: SubscriptionSerializer.new(Subscription.create(subscription_params)), status: :created
+    if Customer.find(params[:customer_id]) && Tea.find(params[:tea_id])
+      render json: SubscriptionSerializer.new(Subscription.create(subscription_params)), status: :created
+    else
+      render status: 404
+    end 
   end
 
   def update

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,2 +1,4 @@
 class ApplicationController < ActionController::API
+  include Response
+  include ExceptionHandler
 end

--- a/app/controllers/concerns/exception_handler.rb
+++ b/app/controllers/concerns/exception_handler.rb
@@ -1,0 +1,9 @@
+module ExceptionHandler 
+  extend ActiveSupport::Concern 
+
+  included do 
+    rescue_from ActiveRecord::RecordNotFound do |e|
+      json_response({ message: e.message }, 404 )
+    end
+  end 
+end

--- a/app/controllers/concerns/response.rb
+++ b/app/controllers/concerns/response.rb
@@ -1,0 +1,5 @@
+module Response 
+  def json_response(object, status = :ok)
+    render json: object, status: status 
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,7 +5,9 @@ Rails.application.routes.draw do
 
       patch '/subscriptions/cancel', to: 'subscriptions#update' 
 
-      resources :subscriptions, only: %i[index create] 
+      get '/customer/subscriptions', to: 'subscriptions#index'
+# make index a customer resource 
+      resources :subscriptions, only: %i[create] 
     end
   end
 end


### PR DESCRIPTION
## Description of Changes:
This PR adds an exception handler to allow for sad path testing in request spec for subscription controller create and update. 

## Put an 'X' next to all that apply
New Test: [X]
New Feature:[X]
Bug Fix: []

## Before You Submit Ensure
All Tests Pass: [X]
Full Coverage: [] 99.51% 
Runs Locally: [X]
